### PR TITLE
move font control logic into WrapText

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,0 @@
-.panelName {
-     font-family: "Diavlo";
-     font-size: 150px;
-     text-anchor: middle;
-     background-color: red;
-}

--- a/src/templates/FoolscapScheduleItem.js
+++ b/src/templates/FoolscapScheduleItem.js
@@ -4,9 +4,10 @@ import {WrapText} from '../svg';
 const ScheduleSign = React.forwardRef((props, ref) => (
   <svg ref={ref} version="1.1" xmlns="http://www.w3.org/2000/svg" width="11in" height="8.5in" viewBox="0 0 1100 850">
     <rect x="0" y="0" width="1100" height="850" stroke="black" fill="white" />
-    <WrapText text={props.panelName} x={50} y={200} width={1000} height={450} fontFamily="Diavlo" fontSize={150}/>
+    <WrapText text={props.panelName} x={50} y={50} width={1000} height={400} fontFamily="Diavlo" fontSize={150}/>
+    <WrapText text={props.panelDescription} x={50} y={450} width={1000} height={350} fontFamily="sans-serif" fontSize={50}/>
   </svg>
 ))
-ScheduleSign.varNames = ["panelName"]
+ScheduleSign.varNames = ["panelName", "panelDescription"]
 
 export default ScheduleSign;

--- a/src/templates/FoolscapScheduleItem.js
+++ b/src/templates/FoolscapScheduleItem.js
@@ -4,7 +4,7 @@ import {WrapText} from '../svg';
 const ScheduleSign = React.forwardRef((props, ref) => (
   <svg ref={ref} version="1.1" xmlns="http://www.w3.org/2000/svg" width="11in" height="8.5in" viewBox="0 0 1100 850">
     <rect x="0" y="0" width="1100" height="850" stroke="black" fill="white" />
-    <WrapText text={props.panelName} x={50} y={200} width={1000} height={450} />
+    <WrapText text={props.panelName} x={50} y={200} width={1000} height={450} fontFamily="Diavlo" fontSize={150}/>
   </svg>
 ))
 ScheduleSign.varNames = ["panelName"]


### PR DESCRIPTION
This resolves #7.

This also solves the issue we were having where styling was being lost in the output SVG, because the styling is now appropriately embedded in the SVG's DOM so it continues to work once exported.